### PR TITLE
Fix conda update bug when additional channels are provided

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -4917,7 +4917,15 @@ const chown_conda_macOs = (config) => __awaiter(this, void 0, void 0, function* 
 const update_conda = (config) => __awaiter(this, void 0, void 0, function* () {
     if (config.update_conda) {
         console.log('Updating conda');
-        yield exec.exec('conda', ['update', '-y', 'conda']);
+        yield exec.exec('conda', [
+            'update',
+            '-y',
+            '-n',
+            'base',
+            '-c',
+            'defaults',
+            'conda'
+        ]);
     }
 });
 /**

--- a/src/conda_actions.ts
+++ b/src/conda_actions.ts
@@ -154,7 +154,15 @@ const chown_conda_macOs = async (config: ConfigObject): Promise<void> => {
 const update_conda = async (config: ConfigObject): Promise<void> => {
   if (config.update_conda) {
     console.log('Updating conda')
-    await exec.exec('conda', ['update', '-y', 'conda'])
+    await exec.exec('conda', [
+      'update',
+      '-y',
+      '-n',
+      'base',
+      '-c',
+      'defaults',
+      'conda'
+    ])
   }
 }
 


### PR DESCRIPTION
This PR fixes an issue when `update-conda==true` is set and `conda-channels`, contains a channel which also lists `conda` (i.e. `conda-forge`).
This can lead to an error on windows, due to mismatching DLLs, [see this issue](https://github.com/conda/conda/issues/9003#issuecomment-553529174).

To prevent this error updating conda is done via:
`conda update -y -n base -c defaults conda`
instead of:
`conda update -y conda`