### PR TITLE
Add deprecation warning for action usage directly from master

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,4 @@
-name: 'Tests'
+name: "Tests"
 on: [push, pull_request]
 
 jobs:
@@ -17,20 +17,9 @@ jobs:
       - name: Running jest tests
         run: npm test
 
-  release-up-to-date:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - name: Install Dependencies
-        run: npm ci
-      - name: Create fresh build release  compare file
-        run: npm run release-compare-file
-      - name: Test if the release and compare file are different
-        run: diff -qywBd dist/index.js compare/index.js
-
   test-integration-default:
     runs-on: ${{ matrix.os }}
-    needs: [jest-tests, release-up-to-date]
+    needs: jest-tests
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macOS-latest]
@@ -54,7 +43,7 @@ jobs:
 
   test-integration-custom:
     runs-on: ${{ matrix.os }}
-    needs: [jest-tests, release-up-to-date]
+    needs: jest-tests
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macOS-latest]
@@ -74,7 +63,7 @@ jobs:
 
   test-no-activation:
     runs-on: ${{ matrix.os }}
-    needs: [jest-tests, release-up-to-date]
+    needs: jest-tests
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macOS-latest]
@@ -98,7 +87,7 @@ jobs:
 
   test-no-activation-setup-python:
     runs-on: ${{ matrix.os }}
-    needs: [jest-tests, release-up-to-date]
+    needs: jest-tests
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macOS-latest]

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,6 +16,12 @@ jobs:
         run: npm run lint
       - name: Running jest tests
         run: npm test
+      - name: Build dist
+        run: npm run package
+      - uses: actions/upload-artifact@v2
+        with:
+          name: dist-built
+          path: dist/index.js
 
   test-integration-default:
     runs-on: ${{ matrix.os }}
@@ -25,11 +31,17 @@ jobs:
         os: [ubuntu-latest, windows-latest, macOS-latest]
     steps:
       - uses: actions/checkout@v2
+      - name: Download built dist
+        uses: actions/download-artifact@v2
+        with:
+          name: dist-built
+          path: dist
       - name: Check initial python version
         run: |
           python --version
           python -c "from __future__ import print_function;import sys;print(sys.executable);print(sys.version_info)"
-      - uses: ./
+      - name: Run setup-conda
+        uses: ./
       - name: Check conda version
         run: conda --version
       - name: Check conda version, with bash on windows
@@ -49,7 +61,13 @@ jobs:
         os: [ubuntu-latest, windows-latest, macOS-latest]
     steps:
       - uses: actions/checkout@v2
-      - uses: ./
+      - name: Download built dist
+        uses: actions/download-artifact@v2
+        with:
+          name: dist-built
+          path: dist
+      - name: Run setup-conda
+        uses: ./
         with:
           update-conda: true
           python-version: 3.6
@@ -69,11 +87,17 @@ jobs:
         os: [ubuntu-latest, windows-latest, macOS-latest]
     steps:
       - uses: actions/checkout@v2
+      - name: Download built dist
+        uses: actions/download-artifact@v2
+        with:
+          name: dist-built
+          path: dist
       - name: Check initial python version
         run: |
           python --version
           python -c "from __future__ import print_function;import sys;print(sys.executable);print(sys.version_info)"
-      - uses: ./
+      - name: Run setup-conda
+        uses: ./
         with:
           activate-conda: false
       - name: Check conda version
@@ -93,6 +117,11 @@ jobs:
         os: [ubuntu-latest, windows-latest, macOS-latest]
     steps:
       - uses: actions/checkout@v2
+      - name: Download built dist
+        uses: actions/download-artifact@v2
+        with:
+          name: dist-built
+          path: dist
       - name: Set up Python 3.8
         uses: actions/setup-python@v1
         with:
@@ -101,7 +130,8 @@ jobs:
         run: |
           python --version
           python -c "from __future__ import print_function;import sys;print(sys.executable);print(sys.version_info)"
-      - uses: ./
+      - name: Run setup-conda
+        uses: ./
         with:
           activate-conda: false
       - name: Check conda version

--- a/.gitignore
+++ b/.gitignore
@@ -98,3 +98,6 @@ typings/
 # ignore none relevat js files
 lib
 compare
+
+# exclude dist folder
+dist/

--- a/README.md
+++ b/README.md
@@ -5,6 +5,10 @@
 This action adds the [`conda`](https://conda.io/projects/conda/en/latest/user-guide/tasks/index.html)
 command from the on the worker preinstalled miniconda version to the known shell commands.
 
+:warning:
+The usage directly from master (`s-weigand/setup-conda@master`) will be deprecated on 2020-07-01,
+use tagged versions instead (i.e. `s-weigand/setup-conda@v1`). This is to ensure that breaking changes in this action, won't break users workflows.
+
 ## Inputs
 
 | Name             | Requirement | Default     | Description                                                                                                                                                          |

--- a/dist/index.js
+++ b/dist/index.js
@@ -2040,6 +2040,12 @@ function run() {
         }
     });
 }
+core.warning(`'setup-conda' will drop support to run it from master!
+You are using 'setup-conda' directly from master ('s-weigand/setup-conda@master' in your workflow).
+To guarantee that breaking changes in this action won't affect the stability of your workflow,
+use tagged versions (i.e. 's-weigand/setup-conda@v1').
+The usage of @master will be deprecated 2020-07-01, make sure to change your workflow until then.
+For more information, see: https://github.com/s-weigand/setup-conda`);
 /* tslint:disable-next-line:no-floating-promises */
 run();
 


### PR DESCRIPTION
This PR adds a warning if `setup-conda` is used directly from master.
To give users the chance to change their workflows, the usage from master will be deprecated at `2020-07-01` and not right now.
This is the last update for this action used directly from master and is equivalent to v1.0.3