### PR TITLE
[ENH] Fix missing bin paths on windows

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,4 +37,10 @@ jobs:
       - name: Check Python version
         run: |
           python --version
-          python -c "from __future__ import print_function;import sys;print(sys.executable);print(sys.version_info)"
+          python -c "import sys;print(sys.executable);print(sys.version_info)"
+      - name: Check env
+        run: printenv
+      - name: Install and check pandoc version
+        run: |
+          conda install pandoc
+          pandoc -v

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,4 @@
-name: "Tests"
+name: 'Tests'
 on: [push, pull_request]
 
 jobs:
@@ -39,7 +39,7 @@ jobs:
       - name: Check initial python version
         run: |
           python --version
-          python -c "from __future__ import print_function;import sys;print(sys.executable);print(sys.version_info)"
+          python -c "import sys;print(sys.executable);print(sys.version_info)"
       - name: Run setup-conda
         uses: ./
       - name: Check conda version
@@ -51,7 +51,7 @@ jobs:
       - name: Check final python version
         run: |
           python --version
-          python -c "from __future__ import print_function;import sys;print(sys.executable);print(sys.version_info)"
+          python -c "import sys;print(sys.executable);print(sys.version_info)"
 
   test-integration-custom:
     runs-on: ${{ matrix.os }}
@@ -77,7 +77,7 @@ jobs:
       - name: Check final python version
         run: |
           python --version
-          python -c "from __future__ import print_function;import sys;print(sys.executable);print(sys.version_info)"
+          python -c "import sys;print(sys.executable);print(sys.version_info)"
 
   test-no-activation:
     runs-on: ${{ matrix.os }}
@@ -95,7 +95,7 @@ jobs:
       - name: Check initial python version
         run: |
           python --version
-          python -c "from __future__ import print_function;import sys;print(sys.executable);print(sys.version_info)"
+          python -c "import sys;print(sys.executable);print(sys.version_info)"
       - name: Run setup-conda
         uses: ./
         with:
@@ -105,7 +105,7 @@ jobs:
       - name: Check final python version
         run: |
           python --version
-          python -c "from __future__ import print_function;import sys;print(sys.executable);print(sys.version_info)"
+          python -c "import sys;print(sys.executable);print(sys.version_info)"
       - name: Check env
         run: printenv
 
@@ -129,7 +129,7 @@ jobs:
       - name: Check initial python version
         run: |
           python --version
-          python -c "from __future__ import print_function;import sys;print(sys.executable);print(sys.version_info)"
+          python -c "import sys;print(sys.executable);print(sys.version_info)"
       - name: Run setup-conda
         uses: ./
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -52,6 +52,10 @@ jobs:
         run: |
           python --version
           python -c "import sys;print(sys.executable);print(sys.version_info)"
+      - name: Install and check pandoc version
+        run: |
+          conda install pandoc
+          pandoc -v
 
   test-integration-custom:
     runs-on: ${{ matrix.os }}
@@ -78,6 +82,10 @@ jobs:
         run: |
           python --version
           python -c "import sys;print(sys.executable);print(sys.version_info)"
+      - name: Install and check pandoc version
+        run: |
+          conda install pandoc
+          pandoc -v
 
   test-no-activation:
     runs-on: ${{ matrix.os }}
@@ -108,6 +116,10 @@ jobs:
           python -c "import sys;print(sys.executable);print(sys.version_info)"
       - name: Check env
         run: printenv
+      - name: Install and check pandoc version
+        run: |
+          conda install pandoc
+          pandoc -v
 
   test-no-activation-setup-python:
     runs-on: ${{ matrix.os }}
@@ -142,3 +154,7 @@ jobs:
           python -c "from __future__ import print_function;import sys;print(sys.executable);print(sys.version_info)"
       - name: Check env
         run: printenv
+      - name: Install and check pandoc version
+        run: |
+          conda install pandoc
+          pandoc -v

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -155,7 +155,7 @@ jobs:
       - name: Check final python version
         run: |
           python --version
-          python -c "from __future__ import print_function;import sys;print(sys.executable);print(sys.version_info)"
+          python -c "import sys;print(sys.executable);print(sys.version_info)"
       - name: Check env
         run: printenv
       - name: Install and check pandoc version

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -52,6 +52,8 @@ jobs:
         run: |
           python --version
           python -c "import sys;print(sys.executable);print(sys.version_info)"
+      - name: Check env
+        run: printenv
       - name: Install and check pandoc version
         run: |
           conda install pandoc
@@ -82,6 +84,8 @@ jobs:
         run: |
           python --version
           python -c "import sys;print(sys.executable);print(sys.version_info)"
+      - name: Check env
+        run: printenv
       - name: Install and check pandoc version
         run: |
           conda install pandoc

--- a/src/conda_actions.ts
+++ b/src/conda_actions.ts
@@ -20,6 +20,7 @@ export const setup_conda = async (config: ConfigObject): Promise<void> => {
   await add_conda_channels(config)
   await update_conda(config)
   await install_python(config)
+  await activate_conda(config)
   await reset_base_python(config, initialPythonLocation)
 }
 

--- a/src/conda_actions.ts
+++ b/src/conda_actions.ts
@@ -1,5 +1,6 @@
 import * as os from 'os'
 import * as path from 'path'
+import * as fs from 'fs'
 import * as temp from 'temp'
 import * as exec from '@actions/exec'
 import * as core from '@actions/core'
@@ -23,16 +24,30 @@ export const setup_conda = async (config: ConfigObject): Promise<void> => {
 }
 
 /**
- * Generates the path of the bin dir of conda_dir.
+ * Only add path_to_add to the PATH variable if it exists
  *
- * @param conda_dir Root directory of the installed conda
+ * @param path_to_add Path to add to the PATH variable
+ */
+const sane_add_path = (path_to_add: string): void => {
+  if (fs.existsSync(path_to_add)) {
+    core.addPath(path_to_add)
+  }
+}
+
+/**
+ * Adds the bin dirs of default Python or Conda to Path
+ *
+ * @param python_dist_dir Root directory of a Python dist dir
  * @param config Configuration of the action
  */
-const get_bin_dir = (conda_dir: string, config: ConfigObject): string => {
+const add_bin_dir = (python_dist_dir: string, config: ConfigObject): void => {
   if (config.os === 'win32') {
-    return path.join(conda_dir, 'Scripts')
+    sane_add_path(path.join(python_dist_dir, 'Scripts'))
+    sane_add_path(path.join(python_dist_dir, 'Library', 'bin'))
+    sane_add_path(path.join(python_dist_dir, 'usr', 'Library', 'bin'))
+    sane_add_path(path.join(python_dist_dir, 'mingw-w64', 'Library', 'bin'))
   } else {
-    return path.join(conda_dir, 'bin')
+    sane_add_path(path.join(python_dist_dir, 'bin'))
   }
 }
 
@@ -44,9 +59,8 @@ const get_bin_dir = (conda_dir: string, config: ConfigObject): string => {
 const addCondaToPath = async (config: ConfigObject): Promise<void> => {
   console.log(`Adding conda path to path: ${process.env.CONDA}`)
   const conda_base_path = process.env.CONDA as string
-  const bin_dir = get_bin_dir(conda_base_path, config)
-  core.addPath(conda_base_path)
-  core.addPath(bin_dir)
+  sane_add_path(conda_base_path)
+  add_bin_dir(conda_base_path, config)
 }
 
 /**
@@ -105,8 +119,8 @@ const reset_base_python = async (
     }
     console.log('Resetting Python to default version at:')
     console.log(pythonLocation)
-    core.addPath(pythonLocation)
-    core.addPath(get_bin_dir(pythonLocation, config))
+    sane_add_path(pythonLocation)
+    add_bin_dir(pythonLocation, config)
   }
 }
 


### PR DESCRIPTION
This PR adds some missing paths on windows, where binary files are saved to.
Namely:

- `$CONDA/Library/bin`
- `$CONDA/usr/Library/bin`
- `$CONDA/mingw-w64/Library/bin`

This actually should have been done by the activation of the conda env (but isn't 😱 ):
https://github.com/s-weigand/setup-conda/blob/be653641f37b3aff9ebcfb19b708afbe39523c39/src/conda_actions.ts#L60

It also adds a sanity check, which checks if a path exists before adding it to the `PATH` variable.

It also adds integration tests for the error.