### PR TITLE
🩹 Fix env activation

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -61,6 +61,55 @@ jobs:
         run: |
           python -m pytest -v integrationtests
 
+  test-integration-test-env:
+    name: Test Env
+    runs-on: ${{ matrix.os }}
+    needs: jest-tests
+    env:
+      CONDA_CHANNELS: 'defaults'
+      ENV_PYTHON: 3.8
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest, macOS-latest]
+    steps:
+      - uses: actions/checkout@v2
+      - name: Prepare tests
+        run: |
+          python --version
+          python integrationtests/prepare_tests.py
+      - name: Download built dist
+        uses: actions/download-artifact@v2
+        with:
+          name: dist-built
+          path: dist
+      - name: Run setup-conda
+        uses: ./
+        with:
+          activate-conda: false
+      - name: Which activate
+        shell: bash -l {0}
+        run: which activate
+      - name: Login shell activate script
+        shell: bash -l {0}
+        run: |
+          conda shell.bash activate base
+          conda shell.posix activate base
+      - name: Install pandoc and graphviz
+        shell: bash -l {0}
+        run: |
+          conda create --name TEST python=3.8
+          source activate TEST
+          conda install pandoc graphviz
+          pip install -q pytest
+          which pip
+      - name: Check env
+        run: printenv
+      - name: Run tests
+        shell: bash -l {0}
+        run: |
+          source activate TEST
+          python -m pytest -v integrationtests
+
   test-integration-custom:
     name: Custom Python
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -62,7 +62,7 @@ jobs:
           python -m pytest -v integrationtests
 
   test-integration-test-env:
-    name: Test Env
+    name: Env login shell
     runs-on: ${{ matrix.os }}
     needs: jest-tests
     env:
@@ -106,6 +106,47 @@ jobs:
         run: printenv
       - name: Run tests
         shell: bash -l {0}
+        run: |
+          source activate TEST
+          python -m pytest -v integrationtests
+
+  test-integration-test-env-no-login:
+    name: Env no login shell
+    runs-on: ${{ matrix.os }}
+    needs: jest-tests
+    env:
+      CONDA_CHANNELS: 'defaults'
+      ENV_PYTHON: 3.8
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest, macOS-latest]
+    steps:
+      - uses: actions/checkout@v2
+      - name: Prepare tests
+        run: |
+          python --version
+          python integrationtests/prepare_tests.py
+      - name: Download built dist
+        uses: actions/download-artifact@v2
+        with:
+          name: dist-built
+          path: dist
+      - name: Run setup-conda
+        uses: ./
+        with:
+          activate-conda: false
+      - name: Create Test env
+        shell: bash
+        run: |
+          conda create --name TEST python=3.8
+          source activate TEST
+          conda install pandoc graphviz
+          pip install -q pytest
+          which pip
+      - name: Check env
+        run: printenv
+      - name: Run tests
+        shell: bash
         run: |
           source activate TEST
           python -m pytest -v integrationtests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -86,15 +86,7 @@ jobs:
         uses: ./
         with:
           activate-conda: false
-      - name: Which activate
-        shell: bash -l {0}
-        run: which activate
-      - name: Login shell activate script
-        shell: bash -l {0}
-        run: |
-          conda shell.bash activate base
-          conda shell.posix activate base
-      - name: Install pandoc and graphviz
+      - name: Create Test env
         shell: bash -l {0}
         run: |
           conda create --name TEST python=3.8

--- a/__tests__/conda_actions.test.ts
+++ b/__tests__/conda_actions.test.ts
@@ -1,9 +1,6 @@
 import * as fs from 'fs'
 import * as path from 'path'
-import {
-  parseActivationScriptOutput,
-  ParsedActivationScriptOutput,
-} from '../src/conda_actions'
+import { parseActivationScriptOutput } from '../src/conda_actions'
 
 describe('Parse evn activation output', () => {
   it('Parse linux activation', async () => {
@@ -12,20 +9,12 @@ describe('Parse evn activation output', () => {
         path.resolve(__dirname, 'data/linux_conda_bash_activation.sh')
       )
       .toString('utf8')
-    const result: ParsedActivationScriptOutput =
-      await parseActivationScriptOutput(activationStr, 'export ', ':')
-    const { condaPaths, envVars } = result
-    expect(condaPaths.length).toBe(3)
-    expect(envVars['CONDA_PREFIX']).toEqual('/usr/share/miniconda')
-    expect(envVars['CONDA_SHLVL']).toEqual('1')
-    expect(envVars['CONDA_DEFAULT_ENV']).toEqual('base')
-    expect(envVars['CONDA_PROMPT_MODIFIER']).toEqual('(base)')
-    expect(envVars['CONDA_EXE']).toEqual('/usr/share/miniconda/bin/conda')
-    expect(envVars['_CE_M']).toEqual('')
-    expect(envVars['_CE_CONDA']).toEqual('')
-    expect(envVars['CONDA_PYTHON_EXE']).toEqual(
-      '/usr/share/miniconda/bin/python'
+    const condaPaths: string[] = await parseActivationScriptOutput(
+      activationStr,
+      'export ',
+      ':'
     )
+    expect(condaPaths.length).toBe(3)
   })
   it('Parse macOs activation', async () => {
     const activationStr = fs
@@ -33,20 +22,12 @@ describe('Parse evn activation output', () => {
         path.resolve(__dirname, 'data/mac_conda_bash_activation.sh')
       )
       .toString('utf8')
-    const result: ParsedActivationScriptOutput =
-      await parseActivationScriptOutput(activationStr, 'export ', ':')
-    const { condaPaths, envVars } = result
-    expect(condaPaths.length).toBe(3)
-    expect(envVars['CONDA_PREFIX']).toEqual('/usr/local/miniconda')
-    expect(envVars['CONDA_SHLVL']).toEqual('1')
-    expect(envVars['CONDA_DEFAULT_ENV']).toEqual('base')
-    expect(envVars['CONDA_PROMPT_MODIFIER']).toEqual('(base)')
-    expect(envVars['CONDA_EXE']).toEqual('/usr/local/miniconda/bin/conda')
-    expect(envVars['_CE_M']).toEqual('')
-    expect(envVars['_CE_CONDA']).toEqual('')
-    expect(envVars['CONDA_PYTHON_EXE']).toEqual(
-      '/usr/local/miniconda/bin/python'
+    const condaPaths: string[] = await parseActivationScriptOutput(
+      activationStr,
+      'export ',
+      ':'
     )
+    expect(condaPaths.length).toBe(3)
   })
   it('Parse windows activation', async () => {
     const activationStr = fs
@@ -54,17 +35,11 @@ describe('Parse evn activation output', () => {
         path.resolve(__dirname, 'data/windows_conda_powershell_activation.ps1')
       )
       .toString('utf8')
-    const result: ParsedActivationScriptOutput =
-      await parseActivationScriptOutput(activationStr, '$Env:', ';')
-    const { condaPaths, envVars } = result
+    const condaPaths: string[] = await parseActivationScriptOutput(
+      activationStr,
+      '$Env:',
+      ';'
+    )
     expect(condaPaths.length).toBe(7)
-    expect(envVars['CONDA_PREFIX']).toEqual('C:\\Miniconda')
-    expect(envVars['CONDA_SHLVL']).toEqual('1')
-    expect(envVars['CONDA_DEFAULT_ENV']).toEqual('base')
-    expect(envVars['CONDA_PROMPT_MODIFIER']).toEqual('(base)')
-    expect(envVars['CONDA_EXE']).toEqual('C:\\Miniconda\\Scripts\\conda.exe')
-    expect(envVars['_CE_M']).toEqual('')
-    expect(envVars['_CE_CONDA']).toEqual('')
-    expect(envVars['CONDA_PYTHON_EXE']).toEqual('C:\\Miniconda\\python.exe')
   })
 })

--- a/integrationtests/test_common.py
+++ b/integrationtests/test_common.py
@@ -22,12 +22,3 @@ def test_conda_channels():
     assert returncode == 0
     assert channel_list == expected
     assert stderr == b""
-
-
-def test_conda_env_vars_set():
-    """Conda env_vars are set"""
-    assert "miniconda" in os.environ["CONDA_PREFIX"].lower()
-    assert "miniconda" in os.environ["CONDA_EXE"].lower()
-    assert "miniconda" in os.environ["CONDA_PYTHON_EXE"].lower()
-    assert int(os.environ["CONDA_SHLVL"]) >= 1
-    assert os.environ["CONDA_DEFAULT_ENV"] != ""

--- a/integrationtests/test_common.py
+++ b/integrationtests/test_common.py
@@ -29,5 +29,5 @@ def test_conda_env_vars_set():
     assert "miniconda" in os.environ["CONDA_PREFIX"].lower()
     assert "miniconda" in os.environ["CONDA_EXE"].lower()
     assert "miniconda" in os.environ["CONDA_PYTHON_EXE"].lower()
-    assert os.environ["CONDA_SHLVL"] == "1"
+    assert int(os.environ["CONDA_SHLVL"]) >= 1
     assert os.environ["CONDA_DEFAULT_ENV"] != ""


### PR DESCRIPTION
Adding the environment variables broke the usage of `source activate <env_name>`.

Changelog:
- Added test for env activation with `source activate <env_name>` (for login shell and none login shell)
- Removed setting of conda env variables when activation conda


closes #125 