### PR TITLE
🩹 Fix broken error handling due to bad import

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -1,4 +1,4 @@
-import core from '@actions/core'
+import { setFailed } from '@actions/core'
 import { loadConfig } from './load_config'
 import { setup_conda } from './conda_actions'
 
@@ -8,9 +8,9 @@ async function run(): Promise<void> {
     await setup_conda(config)
   } catch (error) {
     if (typeof error === 'string') {
-      core.setFailed(error)
+      setFailed(error)
     } else if (error instanceof Error) {
-      core.setFailed(error.message)
+      setFailed(error.message)
     }
   }
 }


### PR DESCRIPTION
This fixes an error caused by a bad import introduced in #315 .

```
TypeError: Cannot read properties of undefined (reading 'setFailed')
```