### PR TITLE
👌 Improve error handling when CONDA environ variable isn't set

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,7 @@ jobs:
     needs: release
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest, macOS-latest]
+        os: [ubuntu-latest, windows-latest, macOS-12]
     steps:
       - name: Setup conda v1
         uses: s-weigand/setup-conda@v1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -49,7 +49,7 @@ jobs:
       CONDA_CHANNELS: 'defaults'
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest, macOS-latest]
+        os: [ubuntu-latest, windows-latest, macOS-12]
     steps:
       - uses: actions/checkout@v4
       - name: Prepare tests
@@ -88,7 +88,7 @@ jobs:
       ENV_PYTHON: 3.8
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest, macOS-latest]
+        os: [ubuntu-latest, windows-latest, macOS-12]
     steps:
       - uses: actions/checkout@v4
       - name: Prepare tests
@@ -131,7 +131,7 @@ jobs:
       ENV_PYTHON: 3.8
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest, macOS-latest]
+        os: [ubuntu-latest, windows-latest, macOS-12]
     steps:
       - uses: actions/checkout@v4
       - name: Prepare tests
@@ -174,7 +174,7 @@ jobs:
     needs: jest-tests
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest, macOS-latest]
+        os: [ubuntu-latest, windows-latest, macOS-12]
     steps:
       - uses: actions/checkout@v4
       - name: Prepare tests
@@ -212,7 +212,7 @@ jobs:
     needs: jest-tests
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest, macOS-latest]
+        os: [ubuntu-latest, windows-latest, macOS-12]
     steps:
       - uses: actions/checkout@v4
       - name: Prepare tests
@@ -250,7 +250,7 @@ jobs:
     needs: jest-tests
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest, macOS-latest]
+        os: [ubuntu-latest, windows-latest, macOS-12]
     steps:
       - uses: actions/checkout@v4
       - name: Prepare tests
@@ -286,7 +286,7 @@ jobs:
     needs: jest-tests
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest, macOS-latest]
+        os: [ubuntu-latest, windows-latest, macOS-12]
     steps:
       - uses: actions/checkout@v4
       - name: Download built dist
@@ -325,7 +325,7 @@ jobs:
       PYPY_TEST: true
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest, macOS-latest]
+        os: [ubuntu-latest, windows-latest, macOS-12]
         pypy-ver: ['pypy3.7']
         include:
           - os: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -354,5 +354,5 @@ jobs:
       - name: Run tests
         run: |
           pypy -m ensurepip
-          pypy -m pip install -q pytest
+          pypy -m pip install --trusted-host pypi.python.org -q pytest
           pypy -m pytest -v integrationtests/test_python_version.py

--- a/README.md
+++ b/README.md
@@ -6,6 +6,9 @@
 This action adds the [`conda`](https://conda.io/projects/conda/en/latest/user-guide/tasks/index.html)
 command from the on the worker preinstalled miniconda version to the known shell commands.
 
+> [!CAUTION]
+> This action [is known to currently not work with macOS runner-images newer than `macOS-12` (i.e. `macOS-latest`)](https://github.com/s-weigand/setup-conda/issues/432).
+
 ## Inputs
 
 | Name             | Requirement | Default     | Description                                                                                                                                                          |

--- a/src/conda_actions.ts
+++ b/src/conda_actions.ts
@@ -59,7 +59,26 @@ const add_bin_dir = (python_dist_dir: string, config: ConfigObject): void => {
 const addCondaToPath = async (config: ConfigObject): Promise<void> => {
   startGroup('Adding conda path to PATH')
   console.log(`${process.env.CONDA}`)
-  const conda_base_path = process.env.CONDA as string
+  const conda_base_path = process.env.CONDA
+  let errorMessageAppendix: string[] = []
+  if (conda_base_path === undefined) {
+    if (config.os == 'darwin' && process.env.ImageOS !== undefined) {
+      const macImageVersion = Number(process.env.ImageOS.replace('macos', ''))
+      if (macImageVersion > 12) {
+        errorMessageAppendix = [
+          'MacOS images newer than "macos-12" (i.e. "macOS-latest") are known to be ' +
+            'incompatible with this action due to a missing miniconda installation.',
+          'See: https://github.com/s-weigand/setup-conda/issues/432',
+        ]
+      }
+    }
+    throw new Error(
+      [
+        'Could not determine conda base path, it seams conda is not installed.',
+        ...errorMessageAppendix,
+      ].join(EOL),
+    )
+  }
   sane_add_path(conda_base_path)
   add_bin_dir(conda_base_path, config)
   endGroup()

--- a/src/conda_actions.ts
+++ b/src/conda_actions.ts
@@ -250,7 +250,7 @@ const chown_conda_macOs = async (config: ConfigObject): Promise<void> => {
  */
 const update_conda = async (config: ConfigObject): Promise<void> => {
   if (config.update_conda) {
-    startGroup('Updateing conda:')
+    startGroup('Updating conda:')
     await exec('conda', [
       'update',
       '-y',

--- a/src/conda_actions.ts
+++ b/src/conda_actions.ts
@@ -56,13 +56,13 @@ const add_bin_dir = (python_dist_dir: string, config: ConfigObject): void => {
  *
  * @param config Configuration of the action
  */
-const addCondaToPath = async (config: ConfigObject): Promise<void> => {
+export const addCondaToPath = async (config: ConfigObject): Promise<void> => {
   startGroup('Adding conda path to PATH')
-  console.log(`${process.env.CONDA}`)
+  console.log('The CONDA env var is:', process.env.CONDA)
   const conda_base_path = process.env.CONDA
   let errorMessageAppendix: string[] = []
   if (conda_base_path === undefined) {
-    if (config.os == 'darwin' && process.env.ImageOS !== undefined) {
+    if (config.os === 'darwin' && process.env.ImageOS !== undefined) {
       const macImageVersion = Number(process.env.ImageOS.replace('macos', ''))
       if (macImageVersion > 12) {
         errorMessageAppendix = [


### PR DESCRIPTION
This action uses the preinstalled `miniconda` and determines its installation base path reading the `CONDA` environ variable.
Up until `macOS-12` this worked for all runner images, however `macOS-13` and `macOS-14` (current `macos-latest`) do not install `miniconda` and workflows fail with:

```
Error: The "path" argument must be of type string. Received undefined
```
See #432 

With this change, the error will be:
```
Error: Could not determine conda base path, it seams conda is not installed.
```
On any system without the `CONDA` environ variable set.
And for macos runner images > 12:
```
 Error: Could not determine conda base path, it seams conda is not installed.
  MacOS images newer than "macos-12" (i.e. "macOS-latest") are known to be incompatible with this action due to a missing miniconda installation.
  See: https://github.com/s-weigand/setup-conda/issues/432

```