### PR TITLE
🩹 Fix activate script parser

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -53,7 +53,7 @@ jobs:
       CONDA_CHANNELS: 'defaults'
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest, macOS-12]
+        os: [ubuntu-latest, windows-latest]
     steps:
       - uses: actions/checkout@v4
       - name: Prepare tests
@@ -92,7 +92,7 @@ jobs:
       ENV_PYTHON: 3.8
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest, macOS-12]
+        os: [ubuntu-latest, windows-latest]
     steps:
       - uses: actions/checkout@v4
       - name: Prepare tests
@@ -135,7 +135,7 @@ jobs:
       ENV_PYTHON: 3.8
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest, macOS-12]
+        os: [ubuntu-latest, windows-latest]
     steps:
       - uses: actions/checkout@v4
       - name: Prepare tests
@@ -179,7 +179,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest, macOS-12]
+        os: [ubuntu-latest, windows-latest]
     steps:
       - uses: actions/checkout@v4
       - name: Prepare tests
@@ -217,7 +217,7 @@ jobs:
     needs: jest-tests
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest, macOS-12]
+        os: [ubuntu-latest, windows-latest]
     steps:
       - uses: actions/checkout@v4
       - name: Prepare tests
@@ -255,7 +255,7 @@ jobs:
     needs: jest-tests
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest, macOS-12]
+        os: [ubuntu-latest, windows-latest]
     steps:
       - uses: actions/checkout@v4
       - name: Prepare tests
@@ -291,7 +291,7 @@ jobs:
     needs: jest-tests
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest, macOS-12]
+        os: [ubuntu-latest, windows-latest]
     steps:
       - uses: actions/checkout@v4
       - name: Download built dist
@@ -330,7 +330,7 @@ jobs:
       PYPY_TEST: true
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest, macOS-12]
+        os: [ubuntu-latest, windows-latest]
         pypy-ver: ['pypy3.7']
         include:
           - os: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -177,6 +177,7 @@ jobs:
       CONDA_CHANNELS: 'defaults,anaconda,conda-forge'
     needs: jest-tests
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macOS-12]
     steps:

--- a/__tests__/conda_actions.test.ts
+++ b/__tests__/conda_actions.test.ts
@@ -8,12 +8,8 @@ describe("Parse env activation output", () => {
     const activationStr = readFileSync(
       resolve(__dirname, "data/linux_conda_bash_activation.sh"),
     ).toString("utf8");
-    const { condaPaths, envVars } = await parseActivationScriptOutput(
-      activationStr,
-      "export ",
-      ":",
-    );
-    expect(condaPaths.length).toBe(3);
+    const { condaPaths, envVars } = await parseActivationScriptOutput(activationStr, "export", ":");
+    expect(condaPaths.length).toBe(4);
     expect(envVars.CONDA_PREFIX).toBe("/usr/share/miniconda/envs/__setup_conda");
     expect(envVars).not.toHaveProperty("CONDA_SHLVL");
     expect(envVars.CONDA_DEFAULT_ENV).toBe("__setup_conda");
@@ -27,11 +23,7 @@ describe("Parse env activation output", () => {
     const activationStr = readFileSync(
       resolve(__dirname, "data/mac_conda_bash_activation.sh"),
     ).toString("utf8");
-    const { condaPaths, envVars } = await parseActivationScriptOutput(
-      activationStr,
-      "export ",
-      ":",
-    );
+    const { condaPaths, envVars } = await parseActivationScriptOutput(activationStr, "export", ":");
     expect(condaPaths.length).toBe(3);
     expect(envVars.CONDA_PREFIX).toBe("/usr/local/miniconda/envs/__setup_conda");
     expect(envVars).not.toHaveProperty("CONDA_SHLVL");
@@ -47,7 +39,7 @@ describe("Parse env activation output", () => {
       resolve(__dirname, "data/windows_conda_powershell_activation.ps1"),
     ).toString("utf8");
     const { condaPaths, envVars } = await parseActivationScriptOutput(activationStr, "$Env:", ";");
-    expect(condaPaths.length).toBe(9);
+    expect(condaPaths.length).toBe(10);
     expect(envVars.CONDA_PREFIX).toBe("C:\\Miniconda\\envs\\__setup_conda");
     expect(envVars).not.toHaveProperty("CONDA_SHLVL");
     expect(envVars.CONDA_DEFAULT_ENV).toBe("__setup_conda");

--- a/__tests__/data/linux_conda_bash_activation.sh
+++ b/__tests__/data/linux_conda_bash_activation.sh
@@ -1,9 +1,10 @@
-export PATH='/usr/share/miniconda/envs/__setup_conda/bin:/usr/share/miniconda/condabin:/usr/share/miniconda:/home/linuxbrew/.linuxbrew/bin'
+unset _CE_M
+unset _CE_CONDA
+PS1='(__setup_conda) '
+export PATH='/usr/share/miniconda/envs/__setup_conda/bin:/usr/share/miniconda/condabin:/usr/share/miniconda/bin:/usr/share/miniconda:/snap/bin:/home/runner/.local/bin:/opt/pipx_bin:/home/runner/.cargo/bin:/home/runner/.config/composer/vendor/bin:/usr/local/.ghcup/bin:/home/runner/.dotnet/tools:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games:/snap/bin'
 export CONDA_PREFIX='/usr/share/miniconda/envs/__setup_conda'
 export CONDA_SHLVL='1'
 export CONDA_DEFAULT_ENV='__setup_conda'
 export CONDA_PROMPT_MODIFIER='(__setup_conda) '
 export CONDA_EXE='/usr/share/miniconda/bin/conda'
-export _CE_M=''
-export _CE_CONDA=''
 export CONDA_PYTHON_EXE='/usr/share/miniconda/bin/python'

--- a/__tests__/data/windows_conda_powershell_activation.ps1
+++ b/__tests__/data/windows_conda_powershell_activation.ps1
@@ -1,9 +1,9 @@
-$Env:PATH = "C:\Miniconda\envs\__setup_conda;C:\Miniconda\envs\__setup_conda\Library\mingw-w64\bin;C:\Miniconda\envs\__setup_conda\Library\usr\bin;C:\Miniconda\envs\__setup_conda\Library\bin;C:\Miniconda\envs\__setup_conda\Scripts;C:\Miniconda\envs\__setup_conda\bin;C:\Miniconda\condabin;C:\Miniconda\Scripts;C:\Miniconda;C:\Program Files\MongoDB\Server\5.0\bin"
+$Env:_CE_M = $null
+$Env:_CE_CONDA = $null
+$Env:PATH = "C:\Miniconda\envs\__setup_conda;C:\Miniconda\envs\__setup_conda\Library\mingw-w64\bin;C:\Miniconda\envs\__setup_conda\Library\usr\bin;C:\Miniconda\envs\__setup_conda\Library\bin;C:\Miniconda\envs\__setup_conda\Scripts;C:\Miniconda\envs\__setup_conda\bin;C:\Miniconda\condabin;C:\Miniconda\Scripts;C:\Miniconda\Library\bin;C:\Miniconda;C:\Program Files\MongoDB\Server\5.0\bin;C:\aliyun-cli;C:\vcpkg;C:\Program Files (x86)\NSIS;C:\tools\zstd;C:\Program Files\Mercurial;C:\hostedtoolcache\windows\stack\3.3.1\x64;C:\cabal\bin;C:\ghcup\bin;C:\mingw64\bin;C:\Program Files\dotnet;C:\Program Files\MySQL\MySQL Server 8.0\bin;C:\Program Files\R\R-4.4.2\bin\x64;C:\SeleniumWebDrivers\GeckoDriver;C:\SeleniumWebDrivers\EdgeDriver;C:\SeleniumWebDrivers\ChromeDriver;C:\Program Files (x86)\sbt\bin;C:\Program Files (x86)\GitHub CLI;C:\Program Files\Git\bin;C:\Program Files (x86)\pipx_bin;C:\npm\prefix;C:\hostedtoolcache\windows\go\1.21.13\x64\bin;C:\hostedtoolcache\windows\Python\3.9.13\x64\Scripts;C:\hostedtoolcache\w
 $Env:CONDA_PREFIX = "C:\Miniconda\envs\__setup_conda"
 $Env:CONDA_SHLVL = "1"
 $Env:CONDA_DEFAULT_ENV = "__setup_conda"
 $Env:CONDA_PROMPT_MODIFIER = "(__setup_conda) "
 $Env:CONDA_EXE = "C:\Miniconda\Scripts\conda.exe"
-$Env:_CE_M = ""
-$Env:_CE_CONDA = ""
 $Env:CONDA_PYTHON_EXE = "C:\Miniconda\python.exe"

--- a/integrationtests/test_common.py
+++ b/integrationtests/test_common.py
@@ -1,4 +1,5 @@
 import os
+import sys
 
 from integrationtests.prepare_tests import run_cmd
 
@@ -13,12 +14,19 @@ def test_conda_installed():
 
 def test_conda_channels():
     """Conda channels are added in order."""
-    returncode, stdout, stderr = run_cmd(" conda config --show channels")
-    expected = os.environ["CONDA_CHANNELS"].split(",")
+    returncode, stdout, stderr = run_cmd("conda config --show channels")
+    expected = [
+        *os.environ["CONDA_CHANNELS"].split(","),
+        # Additional default channels which get appended
+        "https://repo.anaconda.com/pkgs/main",
+        "https://repo.anaconda.com/pkgs/r",
+    ]
+    if sys.platform == "win32":
+        expected.extend(["https://repo.anaconda.com/pkgs/msys2"])
     channel_list = stdout.decode().partition(":")[2].split(" - ")
     channel_list = [channel.strip() for channel in channel_list]
     channel_list.remove("")
 
     assert returncode == 0
-    assert channel_list == expected
     assert stderr == b""
+    assert channel_list == expected

--- a/package-lock.json
+++ b/package-lock.json
@@ -1862,9 +1862,9 @@
       }
     },
     "node_modules/cross-spawn": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
       "dev": true,
       "dependencies": {
         "path-key": "^3.1.0",
@@ -3837,9 +3837,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "5.28.4",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-5.28.4.tgz",
-      "integrity": "sha512-72RFADWFqKmUb2hmmvNODKL3p9hcB6Gt2DOQMis1SEBaV6a4MH8soBvzg+95CYhCKPFedut2JY9bMfrDl9D23g==",
+      "version": "5.28.5",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-5.28.5.tgz",
+      "integrity": "sha512-zICwjrDrcrUE0pyyJc1I2QzBkLM8FINsgOrt6WjA+BgajVq9Nxu2PbFFXUrAggLfDXlZGZBVZYw7WNV5KiBiBA==",
       "dependencies": {
         "@fastify/busboy": "^2.0.0"
       },

--- a/src/conda_actions.ts
+++ b/src/conda_actions.ts
@@ -233,6 +233,8 @@ const add_conda_channels = async (config: ConfigObject): Promise<void> => {
         await exec("conda", ["config", "--add", "channels", channel]);
       }
     }
+    console.log("Conda channels are:");
+    await exec("conda", ["config", "--show", "channels"]);
     endGroup();
   }
 };

--- a/src/conda_actions.ts
+++ b/src/conda_actions.ts
@@ -102,25 +102,36 @@ export const parseActivationScriptOutput = async (
   envExport: string,
   osPathSep: string,
 ): Promise<ParsedActivationScript> => {
-  let condaPaths: string[] = [];
+  const condaPaths: string[] = [];
   const envVars: { [name: string]: string } = {};
-  const lines = activationStr.split(envExport);
+  const lines = activationStr.split(/\r?\n|\r|\n/g);
   for (const line of lines) {
-    if (line.startsWith("PATH")) {
-      const paths = line.replace(/PATH\s?=|'|"|\n|\s/g, "").split(osPathSep);
-      condaPaths = paths
-        .filter((path) => path.toLowerCase().indexOf("miniconda") !== -1)
-        .filter(
-          (orig, index, self) => index === self.findIndex((subSetItem) => subSetItem === orig),
+    if (line.startsWith(envExport)) {
+      const sanitizedLine = line.replace(envExport, "").trim();
+      if (sanitizedLine.startsWith("PATH")) {
+        const paths = sanitizedLine.replace(/PATH\s?=|'|"|\n|\s/g, "").split(osPathSep);
+        condaPaths.push(
+          ...paths
+            .filter((path) => path.toLowerCase().indexOf("miniconda") !== -1)
+            .filter(
+              (orig, index, self) => index === self.findIndex((subSetItem) => subSetItem === orig),
+            ),
         );
-    } else {
-      // eslint-disable-next-line prefer-const
-      let [varName, varValue] = line.replace(/\s?=\s?/g, "=").split("=");
+      } else {
+        const [varName, varValue] = sanitizedLine.replace(/\s?=\s?/g, "=").split("=");
 
-      if (varValue !== undefined && varName !== "CONDA_SHLVL") {
-        varValue = varValue.replace(/('|")?\r?\n$/gm, "").replace(/^'|"/gm, "");
-        envVars[`${varName}`] = varValue;
+        if (varValue !== undefined && varName !== "CONDA_SHLVL") {
+          const sanitizedValue = varValue.replace(/('|")?$/gm, "").replace(/^'|"/gm, "");
+          if (sanitizedValue === "$null") {
+            envVars[varName] = "";
+          } else {
+            envVars[varName] = sanitizedValue;
+          }
+        }
       }
+    }
+    if (line.startsWith("unset")) {
+      envVars[line.replace("unset", "").trim()] = "";
     }
   }
   return { condaPaths, envVars };
@@ -149,7 +160,7 @@ const activate_conda = async (config: ConfigObject): Promise<void> => {
     parsedActivationScript = await parseActivationScriptOutput(activationStr, "$Env:", ";");
   } else {
     await exec("conda", ["shell.bash", "activate", condaEnvName], options);
-    parsedActivationScript = await parseActivationScriptOutput(activationStr, "export ", ":");
+    parsedActivationScript = await parseActivationScriptOutput(activationStr, "export", ":");
   }
   const condaPaths = parsedActivationScript.condaPaths.sort((a, _) => a.indexOf("envs"));
   console.log("\n\nData used for activation:\n", {


### PR DESCRIPTION
This change fixes #495 by adapting `parseActivationScriptOutput` to activate scripts that do not only use env var exports.
This also makes the parser more robust since only expected cases are handled at the cost of silently omitting unexpected cases.

However, there are a few issues with the change that might cause issues in the future:
- [`@actions/core` currently has no proper way to unset env vars](https://github.com/actions/toolkit/issues/1147), so this change uses the poor mans version and sets them to empty string
- [Activating the base conda on windows uses `. "C:\Miniconda\etc\conda\activate.d\openssl_activate.ps1"`](https://github.com/s-weigand/setup-conda/actions/runs/12898115024/job/35964578987?pr=494) which would need additional parsing and is skipped for now